### PR TITLE
Add empty dummy constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ Check the datasheet for details
 
 #### Constructor
 
-- **TCA9555(uint8_t address, TwoWire \*wire = &Wire)** constructor, with default Wire interface. 
+- **TCA9555(uint8_t address, TwoWire \*wire = &Wire)** constructor, with default Wire interface.
 Can be overruled with Wire0..WireN.
+- **TCA9555()** blank constructor. This should only be used as a placeholder for an object created with the above constructor.
 - **TCA9535(uint8_t address, TwoWire \*wire = &Wire)** idem.
+- **TCA9535()** blank constructor. This should only be used as a placeholder for an object created with the above constructor.
 - **uint8_t getType()** returns 35 or 55 depending on type.
 
 

--- a/TCA9555.cpp
+++ b/TCA9555.cpp
@@ -20,7 +20,7 @@
 #define TCA9555_CONFIGURATION_PORT_0      0x06    //  pinMode
 #define TCA9555_CONFIGURATION_PORT_1      0x07
 
-
+TCA9555::TCA9555(){}
 TCA9555::TCA9555(uint8_t address, TwoWire *wire)
 {
   _address = address;
@@ -356,6 +356,7 @@ uint8_t TCA9555::readRegister(uint8_t reg)
 //
 //  TCA9535
 //
+TCA9535::TCA9535(){}
 TCA9535::TCA9535(uint8_t address, TwoWire *wire)
         :TCA9555(address, wire)
 {

--- a/TCA9555.h
+++ b/TCA9555.h
@@ -49,6 +49,7 @@
 class TCA9555
 {
 public:
+  TCA9555();
   TCA9555(uint8_t address, TwoWire *wire = &Wire);
 
 
@@ -115,9 +116,9 @@ protected:
 class TCA9535 : public TCA9555
 {
 public:
+  TCA9535();
   TCA9535(uint8_t address, TwoWire *wire = &Wire);
 };
 
 
 // -- END OF FILE --
-

--- a/examples/TCA9555_useDummyConstructor/TCA9555_useDummyConstructor.ino
+++ b/examples/TCA9555_useDummyConstructor/TCA9555_useDummyConstructor.ino
@@ -1,0 +1,29 @@
+//
+//  FILE: TCA9555_blank_constructor.ino
+//  AUTHOR: Gerry Gralton
+//  PUPROSE: test TCA9555 library
+//  URL: https://github.com/RobTillaart/TCA9555
+
+
+#include "Wire.h"
+#include "TCA9555.h"
+
+
+TCA9555 TCA(0x27);
+
+class Object{
+    TCA9555 Object_TCA;
+
+    public:
+    Object ( TCA9555 TCA_param ){
+        this->Object_TCA = TCA_param;
+    }
+};
+
+void setup() {
+    Object obj = Object ( TCA );
+}
+
+void loop() {
+
+}


### PR DESCRIPTION
I'd appreciate the ability to have dummy constructors so that TCA9555 objects can be fields in other objects. There may be a better way to do this and I'm very open to suggestions. 
Cheers!